### PR TITLE
[bug] post가 존재하지 않을때 getAllPosts 에러 수정

### DIFF
--- a/src/utils/posts.ts
+++ b/src/utils/posts.ts
@@ -12,6 +12,11 @@ import { unified } from 'unified';
 const postsDirectory = path.join(process.cwd(), 'posts');
 
 export async function getAllPosts() {
+  if (!fs.existsSync(postsDirectory)) {
+    fs.mkdirSync(postsDirectory, { recursive: true });
+    return [];
+  }
+
   const fileNames = fs.readdirSync(postsDirectory);
   const allPosts = fileNames.map((fileName) => {
     const slug = fileName.replace(/\.md$/, '');


### PR DESCRIPTION
## 🚀 풀 리퀘스트 제안
post가 존재하지 않을때 getAllPosts 에러 수정

## 📝작업 내용
**[문제]** post가 존재하지 않을때 post 폴더도 존재하지 않아서 getAllPosts가 실행이 안됨
**[해결]** 폴더가 없을 경우 자동으로 생성하도록 코드 수정


